### PR TITLE
feat: Combined search mode, UI overhaul, and v1.75 update (SurfMind)

### DIFF
--- a/backend/config/prompts.yml
+++ b/backend/config/prompts.yml
@@ -38,8 +38,29 @@ prompt:
       - If the content is unknown or empty, reply with: **"Kindly adjust your search for better result."**
       - Do **not** provide information beyond the given context or hallucinate unknown facts.
 
+  combined:
+    system: |
+      You are a helpful assistant that helps users find sites from their browser history and bookmarks. The content provided is retrieved from both sources according to the query. You provide a summary based on the content and URL provided, and indicate whether the result is from history or a bookmark.
+    user: |
+      Generate a short summary based on the provided context. Include the corresponding URL and indicate whether it is from browser history or a bookmark.
+      Context date: {date}
+      URL: {url}
+
+      Content:
+      {context}
+
+      Instructions:
+      - Provide a brief and accurate summary of the context.
+      - Mention whether this result is from browser history or bookmarks.
+      - If you recognize the content, include meaningful information about it.
+        Example:
+          - context: "Facebook"
+          - response: "Facebook is a social media platform that allows users to connect with others, share media, and stay updated. Founded in 2004 by Mark Zuckerberg, it is one of the largest networks globally."
+      - If the content is unknown or empty, reply with: **"Kindly adjust your search for better result."**
+      - Do **not** provide information beyond the given context or hallucinate unknown facts.
+
   relevance: |
-    You are a strict relevance filtering assistant.
+    You are a relevance filtering assistant.
 
     The user has asked the following query:
     "{query}"
@@ -49,6 +70,10 @@ prompt:
     - Title
     - Source URL
     - Content snippet
+
+    Note: Some blocks may come from bookmarks, where the content is only the page title.
+    For such blocks, judge relevance using the Title and Source URL — do NOT penalise a
+    block just because its content is short or sparse.
 
     Content blocks:
     {content_blocks}
@@ -60,12 +85,12 @@ prompt:
     3. A block is relevant if it:
       - Directly answers the query, OR
       - Is strongly related to the topic, OR
-      - Contains key terms or semantically similar concepts.
+      - Contains key terms or semantically similar concepts in the Title or URL.
 
     4. A block is NOT relevant if:
       - It discusses a completely unrelated topic.
       - It belongs to a clearly unrelated domain (e.g., scholarships for a math query).
-      - It contains no meaningful semantic connection to the query.
+      - Neither the Title, URL, nor Content has any connection to the query.
 
     Important Rules:
     - Do NOT remove blocks that are partially relevant.

--- a/backend/src/controller/core_controller.py
+++ b/backend/src/controller/core_controller.py
@@ -36,12 +36,20 @@ router = APIRouter(prefix="/v1", tags=["Core"])
 @router.post("/save-data", response_model=Dict[str, Any])
 def save_data(payload: DataRequest):
     """Persist user history/bookmark data to Redis with a short TTL.
-    Uses the payload user_id and flag to build a stable Redis key.
+    For flag='combined', stores history and bookmarks under separate sub-keys.
+    Uses the payload user_id and flag to build stable Redis keys.
     """
     try:
         redis_client.ping()
-        redis_key = f"user:{payload.user_id}:{payload.flag}"
-        redis_client.set(redis_key, payload.json(), ex=3600)
+
+        if payload.flag == "combined":
+            history_payload = {"data": [item.dict() for item in payload.data]}
+            bookmark_payload = {"data": [item.dict() for item in payload.bookmarks]}
+            redis_client.set(f"user:{payload.user_id}:ch", json.dumps(history_payload), ex=3600)
+            redis_client.set(f"user:{payload.user_id}:cb", json.dumps(bookmark_payload), ex=3600)
+        else:
+            redis_key = f"user:{payload.user_id}:{payload.flag}"
+            redis_client.set(redis_key, payload.json(), ex=3600)
 
         return {"success": True, "message": "Data saved successfully"}
 
@@ -91,17 +99,30 @@ def search_stream(
     service: CoreRetrieval = Depends(Retrieval.get_retrieval_service),
 ):
     """Stream RAG search progress and results via Server-Sent Events.
+    For flag='combined', loads history and bookmarks from separate Redis sub-keys.
     Reads user data from Redis and yields stepwise progress payloads.
     Emits a final event with the full response or an error event.
     """
-    redis_key = f"user:{payload.user_id}:{payload.flag}"
-    user_data = redis_client.get(redis_key)
-    history: dict = json.loads(user_data) if user_data else {}
+    if payload.flag == "combined":
+        history_raw = redis_client.get(f"user:{payload.user_id}:ch")
+        bookmark_raw = redis_client.get(f"user:{payload.user_id}:cb")
+        history_data = json.loads(history_raw).get("data", []) if history_raw else []
+        bookmark_data = json.loads(bookmark_raw).get("data", []) if bookmark_raw else []
+    else:
+        redis_key = f"user:{payload.user_id}:{payload.flag}"
+        user_data = redis_client.get(redis_key)
+        history_data = json.loads(user_data).get("data", []) if user_data else []
+        bookmark_data = []
 
     def event_stream():
         try:
-            history_data = history.get("data", [])
-            for event in service.stream_rag(data=payload, history=history_data):
+            if payload.flag == "combined":
+                gen = service.stream_combined_rag(
+                    data=payload, history=history_data, bookmarks=bookmark_data
+                )
+            else:
+                gen = service.stream_rag(data=payload, history=history_data)
+            for event in gen:
                 yield f"data: {json.dumps(event)}\n\n"
         except Exception as exc:
             logger.error(exc)

--- a/backend/src/models/core.py
+++ b/backend/src/models/core.py
@@ -3,7 +3,7 @@ Defines Pydantic schemas used across controllers and services.
 """
 
 from pydantic import BaseModel, Field
-from typing import List
+from typing import List, Optional
 
 
 class Document:
@@ -42,6 +42,16 @@ class Ans_bookmark(BaseModel):
     url: str = Field(description="the url of the context")
 
 
+class Ans_combined(BaseModel):
+    """Structured output schema for combined history+bookmark responses.
+    Captures the URL, optional date, and source type.
+    """
+
+    url: str = Field(description="the url of the context")
+    date: Optional[str] = Field(default=None, description="the date of the context if available")
+    source_type: str = Field(description="the source type: history or bookmark")
+
+
 class HistoryItem(BaseModel):
     """Schema for a single history record in client payloads.
     Contains URL, content, and optional date.
@@ -58,11 +68,13 @@ class HistoryItem(BaseModel):
 class DataRequest(BaseModel):
     """Request schema for saving user data to cache.
     Includes user identity, flag type, and history items.
+    For flag="combined", bookmarks field carries the bookmark items.
     """
 
     user_id: str = Field(alias="userId")
     flag: str = Field(default="history")
     data: List[HistoryItem]
+    bookmarks: List[HistoryItem] = []
 
 
 class SearchRequest(BaseModel):

--- a/backend/src/services/core_service/main.py
+++ b/backend/src/services/core_service/main.py
@@ -4,6 +4,8 @@ Includes a mock streamer to test UI progress handling.
 """
 
 import time
+from rich import print as rprint
+from concurrent.futures import ThreadPoolExecutor
 from typing import List, Dict, Any, Generator
 from src.services.llm_service.llm_provider import LLMProvider
 from src.models.core import Document, SearchRequest, SearchResponse
@@ -191,6 +193,102 @@ class CoreRetrieval:
         #     res = self._empty_response("No relevant data found")
         #     yield self._stream_event("final", res.model_dump())
         #     return
+
+        res = SearchResponse(
+            success=True,
+            result=result,
+            format=final_output,
+            model=model,
+            docs=validated_docs,
+        )
+        yield self._stream_event("final", res.model_dump())
+
+    def stream_combined_rag(
+        self, data: SearchRequest, history: List[dict], bookmarks: List[dict]
+    ) -> Generator[Dict[str, Any], None, None]:
+        """Stream combined history+bookmark search progress via SSE.
+        Runs retrieval independently on each corpus so both sources are
+        guaranteed representation (k results each), then interleaves them
+        before post-processing.
+        """
+        ques = data.query
+        history_docs = self._build_parent_documents(history=history, flag="history")
+        bookmark_docs = self._build_parent_documents(history=bookmarks, flag="bookmark")
+
+        if not history_docs and not bookmark_docs:
+            res = self._empty_response("No data found for combined search")
+            yield self._stream_event("final", res.dict())
+            return
+
+        # Retrieve independently so each corpus gets its own k=3 slots,
+        # preventing history from crowding out bookmarks.
+        def _safe_retrieve(docs):
+            if not docs:
+                return []
+            try:
+                return self.rag.retrieve_parents(query=ques, parent_docs=docs)
+            except Exception as exc:
+                logger.warning("Retrieval failed for corpus: %s", exc)
+                return []
+
+        with ThreadPoolExecutor(max_workers=2) as executor:
+            hist_future = executor.submit(_safe_retrieve, history_docs)
+            bm_future = executor.submit(_safe_retrieve, bookmark_docs)
+            history_parents = hist_future.result()
+            bookmark_parents = bm_future.result()
+
+        total_retrieved = len(history_parents) + len(bookmark_parents)
+        yield self._stream_event("retrieved_parents", {"count": total_retrieved})
+
+        if not history_parents and not bookmark_parents:
+            res = self._empty_response("No relevant data found")
+            yield self._stream_event("final", res.dict())
+            return
+
+        # Post-process each source independently and sequentially.
+        # Bookmark content is sparse (title only), so judging it alongside
+        # richer history results causes the LLM to unfairly drop bookmarks.
+        # Separate evaluation gives each source a fair relevance check.
+        # Sequential (not parallel) to avoid simultaneous LLM calls hitting
+        # rate limits — each corpus is ≤3 docs so the latency cost is small.
+        def _safe_post_process(docs):
+            if not docs:
+                return []
+            try:
+                return self.post_processing.post_process(ques=ques, docs=docs)
+            except Exception as exc:
+                logger.warning("Post-processing failed for corpus: %s", exc)
+                return []
+
+        rprint("Validating history parents...", history_parents)
+        validated_history = _safe_post_process(history_parents)
+        rprint("Validating bookmark parents...", bookmark_parents)
+        validated_bookmarks = _safe_post_process(bookmark_parents)
+
+        # Merge: history results first, then bookmarks (Popup.js re-splits by metadata.type)
+        validated_docs = validated_history + validated_bookmarks
+        yield self._stream_event(
+            "post_processing", {"validated_docs": len(validated_docs)}
+        )
+
+        if not validated_docs:
+            res = self._empty_response("No relevant data found after filtering")
+            yield self._stream_event("final", res.dict())
+            return
+
+        top_doc: dict = validated_docs[0]
+        context = top_doc.get("content", "")
+        source = top_doc.get("metadata", {}).get("source", "")
+        date = top_doc.get("metadata", {}).get("date", None)
+
+        result, model = self.llm_rag.safe_invoke_llm_response(
+            context=context, date=date, url=source, flag="combined"
+        )
+        yield self._stream_event("llm_response", {"text": result, "model": model})
+
+        pchain = self.llm_rag.structure(flag="combined")
+        final_output = pchain.invoke({"content": result})
+        yield self._stream_event("output_parser", {"format": final_output})
 
         res = SearchResponse(
             success=True,

--- a/backend/src/services/core_service/rag.py
+++ b/backend/src/services/core_service/rag.py
@@ -10,6 +10,7 @@ Hybrid RAG implementation for SurfMind (FREE version)
 import re
 import difflib
 from collections import defaultdict
+from concurrent.futures import ThreadPoolExecutor
 from typing import List, Tuple, Optional, Any, Dict, Set
 
 from langchain_core.documents import Document
@@ -21,7 +22,7 @@ from langchain_community.retrievers import BM25Retriever
 from langchain_community.vectorstores import FAISS
 
 from src.models.ai_models import Models
-from src.models.core import Ans_bookmark, Ans_history
+from src.models.core import Ans_bookmark, Ans_combined, Ans_history
 from src.services.llm_service.llm_provider import LLMProvider
 from src.services.llm_service.prompt_builder import Prompts
 from src.utility.provider import EmbeddingsProvider as ef
@@ -186,13 +187,20 @@ class HybridRAGService:
         vocabulary = self._build_vocabulary(child_docs)
         expanded_query = self.expand_query_typo_tolerant(query, vocabulary)
 
-        # Step 2: build retrievers
-        bm25 = self._build_bm25_retriever(child_docs)
-        faiss = self._build_faiss_retriever(child_docs)
+        # Step 2 & 3: build retrievers and invoke in parallel
+        def _run_bm25():
+            bm25 = self._build_bm25_retriever(child_docs)
+            return bm25.invoke(expanded_query)
 
-        # Step 3: retrieve child docs
-        bm25_hits = bm25.invoke(expanded_query)
-        faiss_hits = faiss.invoke(query)
+        def _run_faiss():
+            faiss = self._build_faiss_retriever(child_docs)
+            return faiss.invoke(query)
+
+        with ThreadPoolExecutor(max_workers=2) as executor:
+            bm25_future = executor.submit(_run_bm25)
+            faiss_future = executor.submit(_run_faiss)
+            bm25_hits = bm25_future.result()
+            faiss_hits = faiss_future.result()
 
         # Step 4: merge + map back to parents
         return self._map_to_parents(
@@ -261,23 +269,35 @@ class LLMRag:
         """Build the response chain for the specified flag.
         Returns a runnable that produces plain text output.
         """
-        prompt_history = self.prompts.history_prompt()
-        prompt_bookmark = self.prompts.bookmark_prompt()
         if flag == "history":
+            prompt = self.prompts.history_prompt()
             chain = (
                 {
                     "context": RunnablePassthrough(),
                     "url": RunnablePassthrough(),
                     "date": RunnablePassthrough(),
                 }
-                | prompt_history
+                | prompt
                 | llm
                 | StrOutputParser()
             )
         elif flag == "bookmark":
+            prompt = self.prompts.bookmark_prompt()
             chain = (
                 {"context": RunnablePassthrough(), "url": RunnablePassthrough()}
-                | prompt_bookmark
+                | prompt
+                | llm
+                | StrOutputParser()
+            )
+        elif flag == "combined":
+            prompt = self.prompts.combined_prompt()
+            chain = (
+                {
+                    "context": RunnablePassthrough(),
+                    "url": RunnablePassthrough(),
+                    "date": RunnablePassthrough(),
+                }
+                | prompt
                 | llm
                 | StrOutputParser()
             )
@@ -294,6 +314,8 @@ class LLMRag:
             parser = JsonOutputParser(pydantic_object=Ans_history)
         elif flag == "bookmark":
             parser = JsonOutputParser(pydantic_object=Ans_bookmark)
+        elif flag == "combined":
+            parser = JsonOutputParser(pydantic_object=Ans_combined)
         else:
             raise ValueError(f"Unknown flag '{flag}'")
         promptParser = self.prompts.parser_prompt(parser, flag)
@@ -308,9 +330,9 @@ class LLMRag:
         self, context: str, date: Optional[str], url: str, flag: str, chain: Runnable
     ) -> str:
         """Invoke a chain with the correct input mapping.
-        Includes date for history and omits it for bookmarks.
+        Includes date for history/combined and omits it for bookmarks.
         """
-        if flag == "history":
+        if flag in ("history", "combined"):
             return chain.invoke({"context": context, "date": date, "url": url})
         return chain.invoke({"context": context, "url": url})
 

--- a/backend/src/services/llm_service/prompt_builder.py
+++ b/backend/src/services/llm_service/prompt_builder.py
@@ -51,6 +51,21 @@ class Prompts:
 
         return prompt
 
+    def combined_prompt(
+        self,
+    ):
+        """Build the combined history+bookmark response prompt template.
+        Returns a chat prompt ready for invocation.
+        """
+        prompts = self.utility.load_prompts()
+        template_S = prompts["prompt"]["combined"]["system"]
+        system_message_prompt = SystemMessagePromptTemplate.from_template(template_S)
+
+        template = prompts["prompt"]["combined"]["user"]
+        prompt = ChatPromptTemplate.from_messages([system_message_prompt, template])
+
+        return prompt
+
     def parser_prompt(self, parser, flag):
         """Create a parser prompt for structured output extraction.
         Returns a PromptTemplate configured with format instructions.
@@ -58,6 +73,14 @@ class Prompts:
         if flag == "history":
             promptParser = PromptTemplate(
                 template="Extract date and url from the given content.\n{format_instructions}\n{content}\n.",
+                input_variables=["content"],
+                partial_variables={
+                    "format_instructions": parser.get_format_instructions()
+                },
+            )
+        elif flag == "combined":
+            promptParser = PromptTemplate(
+                template="Extract url, date (if available), and source_type (history or bookmark) from the given content.\n{format_instructions}\n{content}\n.",
                 input_variables=["content"],
                 partial_variables={
                     "format_instructions": parser.get_format_instructions()

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,6 +12,7 @@
         "@testing-library/react": "^13.4.0",
         "@testing-library/user-event": "^13.5.0",
         "eslint": "^8.57.0",
+        "lucide-react": "^1.7.0",
         "react": "^18.3.1",
         "react-dom": "^18.3.1",
         "react-scripts": "5.0.1",
@@ -12448,6 +12449,15 @@
       "integrity": "sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==",
       "dependencies": {
         "yallist": "^3.0.2"
+      }
+    },
+    "node_modules/lucide-react": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/lucide-react/-/lucide-react-1.7.0.tgz",
+      "integrity": "sha512-yI7BeItCLZJTXikmK4KNUGCKoGzSvbKlfCvw44bU4fXAL6v3gYS4uHD1jzsLkfwODYwI6Drw5Tu9Z5ulDe0TSg==",
+      "license": "ISC",
+      "peerDependencies": {
+        "react": "^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0"
       }
     },
     "node_modules/lz-string": {

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
     "@testing-library/react": "^13.4.0",
     "@testing-library/user-event": "^13.5.0",
     "eslint": "^8.57.0",
+    "lucide-react": "^1.7.0",
     "react": "^18.3.1",
     "react-dom": "^18.3.1",
     "react-scripts": "5.0.1",

--- a/public/manifest.json
+++ b/public/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "SurfMind - Smarter Browsing",
-  "version": "1.70.1",
+  "version": "1.75.0",
   "description": "Chrome extension designed to enhance your browsing experience by intelligently managing the websites you visit and bookmark",
   "permissions": [
     "tabs",

--- a/src/Components/Combined.js
+++ b/src/Components/Combined.js
@@ -1,11 +1,11 @@
 import { useContext, useEffect, useState } from "react";
-import { Search, Bookmark } from "lucide-react";
+import { Search, GitMerge } from "lucide-react";
 import { userContext } from "../context/userContext";
 
-const Bookmarks = ({ host }) => {
-  const { state, setState, searchStream, syncBookmarks } =
+const Combined = ({ host }) => {
+  const { state, setState, searchStream, syncCombined } =
     useContext(userContext);
-  const { userId } = state;
+  const { userId, data } = state;
   const [ques, setQues] = useState("");
   const [loader, setLoader] = useState("");
   const [disable, setDisable] = useState(false);
@@ -16,7 +16,8 @@ const Bookmarks = ({ host }) => {
       const result = await fetchBookmarks();
       setBookmarks(result);
       if (userId && host) {
-        await syncBookmarks(host, result, userId);
+        const historyData = data.navigationData || [];
+        await syncCombined(host, historyData, result, userId);
       }
     }
     getData();
@@ -73,8 +74,8 @@ const Bookmarks = ({ host }) => {
 
   const handleSearch = async (e) => {
     e.preventDefault();
-    if (!bookmark || bookmark.length === 0) {
-      setState({ noti: "No bookmarks found" });
+    if ((data.navigationData || []).length === 0 && bookmark.length === 0) {
+      setState({ noti: "No history or bookmarks found" });
       return;
     }
 
@@ -88,9 +89,9 @@ const Bookmarks = ({ host }) => {
     });
 
     try {
-      await searchStream({ host, query: ques, userId, flag: "bookmark" });
+      await searchStream({ host, query: ques, userId, flag: "combined" });
     } catch {
-      setState({ noti: "There is a problem with bookmark search" });
+      setState({ noti: "There is a problem with combined search" });
     } finally {
       setLoader("");
       setDisable(false);
@@ -101,30 +102,34 @@ const Bookmarks = ({ host }) => {
     <div>
       <div className="mb-3">
         <label
-          htmlFor="bmInput"
+          htmlFor="combinedInput"
           className="form-label text-muted d-flex align-items-center gap-1"
           style={{ fontSize: "14px" }}
         >
-          <Bookmark size={14} className="text-danger" />
-          Search Your <span className="text-danger">Bookmarks</span>
+          <GitMerge size={14} className="text-success" />
+          Search <span className="text-success">History + Bookmarks</span>
         </label>
         <input
           type="text"
           className="form-control"
-          id="bmInput"
+          id="combinedInput"
           value={ques}
           onChange={(e) => setQues(e.target.value)}
-          placeholder="Search Bookmarks"
-          aria-describedby="bmHelp"
+          placeholder="Search across history and bookmarks"
+          aria-describedby="combinedHelp"
           style={{ fontSize: "14px" }}
         />
-        <div id="bmHelp" className="form-text" style={{ fontSize: "12px" }}>
-          Type Keywords for better results
+        <div
+          id="combinedHelp"
+          className="form-text"
+          style={{ fontSize: "12px" }}
+        >
+          Searches last 50 history items + half your bookmarks (newest first)
         </div>
       </div>
       <button
         type="submit"
-        className="btn btn-danger btn-sm d-inline-flex align-items-center gap-1"
+        className="btn btn-success btn-sm d-inline-flex align-items-center gap-1"
         style={{ borderRadius: "10px" }}
         disabled={disable || ques === ""}
         onClick={handleSearch}
@@ -139,4 +144,4 @@ const Bookmarks = ({ host }) => {
   );
 };
 
-export default Bookmarks;
+export default Combined;

--- a/src/Components/Popup.js
+++ b/src/Components/Popup.js
@@ -1,15 +1,23 @@
-import { useContext, useEffect, useRef } from "react";
+import { useContext, useEffect, useRef, useState } from "react";
+import {
+  Search,
+  Trash2,
+  History,
+  Bookmark,
+  GitMerge,
+  ArrowRight,
+} from "lucide-react";
 import Bookmarks from "./Bookmarks";
+import Combined from "./Combined";
 import Update from "./Update";
 import { userContext } from "../context/userContext";
-// import { hist } from "./check_data";
 
 const Popup = (props) => {
   const { host } = props.prop;
   const { state, setState, initializePopup, searchStream, syncHistory } =
     useContext(userContext);
   const {
-    historyTab,
+    activeTab,
     query,
     head,
     parsed,
@@ -52,10 +60,11 @@ const Popup = (props) => {
     const match = url.match(/https?:\/\/(www\.)?([^\.]+)/);
     return match ? match[2] : null;
   };
+
   const handleShowUpdate = async () => {
-    await chrome.storage.local.set({ "sm-update-flag-v1.7": true });
-    await chrome.storage.local.remove("sm-update-flag-v1.6");
-    setState({ updateFlag: false });
+    await chrome.storage.local.set({ "sm-update-flag-v1.75": true });
+    await chrome.storage.local.remove("sm-update-flag-v1.7");
+    setState({ updateFlag: true });
   };
 
   const clearAllHistory = async () => {
@@ -72,29 +81,19 @@ const Popup = (props) => {
   const extractUrlFromHead = (head) => {
     if (!head || !head.includes("URL:"))
       return { summary: head || "", url: null };
-
     const [summary, urlRaw] = head.split("URL:");
     const url = urlRaw.trim();
-
     const displayUrl = url.length > 50 ? url.slice(0, 50) + "..." : url;
-
-    return {
-      summary: summary.trim(),
-      url: displayUrl,
-    };
+    return { summary: summary.trim(), url: displayUrl };
   };
 
   function getDaysAgo(searchDateStr) {
     const today = new Date();
     const searchDate = new Date(searchDateStr);
-
-    // Remove time from both dates
     today.setHours(0, 0, 0, 0);
     searchDate.setHours(0, 0, 0, 0);
-
     const diffTime = today - searchDate;
     const diffDays = Math.floor(diffTime / (1000 * 60 * 60 * 24));
-
     if (diffDays === 0) return "Today";
     if (diffDays === 1) return "1 day ago";
     return `${diffDays} days ago`;
@@ -103,28 +102,11 @@ const Popup = (props) => {
   const handleSearch = async (e) => {
     e.preventDefault();
     const dataa = data.navigationData;
-    // const dataa = hist;
     if (!dataa || dataa.length === 0) {
       setState({ noti: "There is no data in History", disable: false });
       return;
     }
-    await searchStream({
-      host,
-      query,
-      userId,
-      flag: "history",
-    });
-  };
-
-  const handleTab = () => {
-    setState({
-      historyTab: false,
-      docs: [],
-      head: "",
-      parsed: { summary: "", url: null },
-      noti: "",
-      query: "",
-    });
+    await searchStream({ host, query, userId, flag: "history" });
   };
 
   const handleClearAllHistory = async () => {
@@ -139,39 +121,208 @@ const Popup = (props) => {
     });
   };
 
+  const handleTabChange = (tab) => {
+    setState({
+      activeTab: tab,
+      docs: [],
+      head: "",
+      parsed: { summary: "", url: null },
+      noti: "",
+      query: "",
+    });
+  };
+
   const getShortUrl = (url) => {
     if (url.length > 30) {
-      const short_url =
-        url.replace("https://", "").slice(0, 15) + "...." + url.slice(-8);
-      return short_url;
+      return url.replace("https://", "").slice(0, 15) + "...." + url.slice(-8);
     }
     return url.replace("https://", "");
   };
 
+  const [dropdownOpen, setDropdownOpen] = useState(false);
+
+  const tabLabel = {
+    history: "History",
+    bookmark: "Bookmarks",
+    combined: "Combined",
+  };
+  const tabColor = {
+    history: "primary",
+    bookmark: "danger",
+    combined: "success",
+  };
+
+  // For combined view, split docs by source type
+  const historyDocs = docs.filter((d) => d.metadata?.type === "history");
+  const bookmarkDocs = docs.filter((d) => d.metadata?.type === "bookmark");
+  const isCombined = activeTab === "combined";
+
+  const DocCard = ({ doc, showDate }) => {
+    const domain =
+      doc.metadata.source && extractDomainName(doc.metadata.source);
+    return (
+      <div
+        className="bg-light p-2 border rounded mt-1"
+        style={{ cursor: "pointer" }}
+        onClick={() => chrome.tabs.create({ url: doc.metadata.source })}
+        title={doc.metadata.source}
+      >
+        <p style={{ margin: "0", padding: "0", fontSize: "13px" }}>
+          {domain ? domain.charAt(0).toUpperCase() + domain.slice(1) : ""}
+          {doc.metadata.title?.length > 0 ? ` | ${doc.metadata.title}` : ""}
+        </p>
+        <div className="d-flex">
+          <p
+            className="text-muted flex-grow-1"
+            style={{ fontSize: "12px", margin: "0", padding: "0" }}
+          >
+            {getShortUrl(doc.metadata.source)}
+          </p>
+          {showDate && doc.metadata.date && (
+            <p
+              className="text-muted"
+              style={{ fontSize: "12px", margin: "0", padding: "0" }}
+            >
+              {getDaysAgo(doc.metadata.date)}
+            </p>
+          )}
+        </div>
+      </div>
+    );
+  };
+
   return (
     <div className="container p-4" style={{ width: "350px" }}>
-      {historyTab ? (
+      {/* ── Header ── */}
+      <div className="d-flex align-items-center mb-3">
+        <span className="flex-grow-1">
+          <span
+            className="fw-bold"
+            style={{
+              fontSize: "16px",
+              display: "inline-block",
+              background: "linear-gradient(90deg, #0d6efd, #6f42c1)",
+              WebkitBackgroundClip: "text",
+              WebkitTextFillColor: "transparent",
+            }}
+          >
+            SurfMind
+            {syncing && (
+              <span
+                className="badge bg-info text-dark ms-2"
+                style={{ fontSize: "10px", WebkitTextFillColor: "initial" }}
+              >
+                Syncing
+              </span>
+            )}
+          </span>
+        </span>
+
+        {/* ── Tab dropdown ── */}
+        <div className="position-relative">
+          {/* NEW badge — tied to updateFlag so it disappears when user dismisses the Update box */}
+          {!updateFlag && (
+            <span
+              className="badge bg-danger position-absolute"
+              style={{
+                fontSize: "9px",
+                borderRadius: "4px",
+                top: "-7px",
+                right: "-7px",
+                zIndex: 2,
+              }}
+            >
+              NEW
+            </span>
+          )}
+          <button
+            className={`btn btn-sm btn-outline-${tabColor[activeTab]} dropdown-toggle d-flex align-items-center gap-1`}
+            style={{ borderRadius: "6px", minWidth: "105px", fontSize: "13px" }}
+            onClick={() => setDropdownOpen((o) => !o)}
+          >
+            {activeTab === "history" && <History size={13} />}
+            {activeTab === "bookmark" && <Bookmark size={13} />}
+            {activeTab === "combined" && <GitMerge size={13} />}
+            {tabLabel[activeTab]}
+          </button>
+          {dropdownOpen && (
+            <>
+              {/* backdrop to close on outside click */}
+              <div
+                className="position-fixed top-0 start-0 w-100 h-100"
+                style={{ zIndex: 100 }}
+                onClick={() => setDropdownOpen(false)}
+              />
+              <ul
+                className="dropdown-menu show shadow"
+                style={{
+                  position: "absolute",
+                  right: 0,
+                  left: "auto",
+                  top: "calc(100% + 4px)",
+                  zIndex: 1050,
+                  borderRadius: "6px",
+                  minWidth: "130px",
+                  border: "1.5px solid #dee2e6",
+                }}
+              >
+                <li>
+                  <button
+                    className="dropdown-item rounded-top d-flex align-items-center gap-2"
+                    onClick={() => {
+                      handleTabChange("history");
+                      setDropdownOpen(false);
+                    }}
+                  >
+                    <History size={14} className="text-primary" /> History
+                  </button>
+                </li>
+                <li>
+                  <button
+                    className="dropdown-item d-flex align-items-center gap-2"
+                    onClick={() => {
+                      handleTabChange("bookmark");
+                      setDropdownOpen(false);
+                    }}
+                  >
+                    <Bookmark size={14} className="text-danger" /> Bookmarks
+                  </button>
+                </li>
+                <li>
+                  <button
+                    className="dropdown-item rounded-bottom d-flex align-items-center gap-2"
+                    onClick={() => {
+                      handleTabChange("combined");
+                      setDropdownOpen(false);
+                    }}
+                  >
+                    <GitMerge size={14} className="text-success" /> Combined
+                    <span
+                      className="badge bg-success ms-auto"
+                      style={{ fontSize: "9px" }}
+                    >
+                      New
+                    </span>
+                  </button>
+                </li>
+              </ul>
+            </>
+          )}
+        </div>
+      </div>
+
+      {/* ── Views ── */}
+      {activeTab === "history" && (
         <div>
           <div className="mb-3">
-            <div className="d-flex">
-              <label
-                for="exampleInput"
-                className="form-label text-muted flex-grow-1"
-                style={{ fontSize: "14px" }}
-              >
-                Search Your <span className="text-primary">History</span>
-                {syncing && (
-                  <span className="badge bg-info text-dark ms-2">Syncing</span>
-                )}
-              </label>
-              <p
-                className="text-danger"
-                style={{ fontSize: "14px", cursor: "pointer" }}
-                onClick={handleTab}
-              >
-                Bookmarks
-              </p>
-            </div>
+            <label
+              htmlFor="exampleInput"
+              className="form-label text-muted d-flex align-items-center gap-1"
+              style={{ fontSize: "14px" }}
+            >
+              <History size={14} className="text-primary" />
+              Search Your <span className="text-primary">History</span>
+            </label>
             <input
               type="text"
               className="form-control"
@@ -181,45 +332,42 @@ const Popup = (props) => {
               placeholder="Search History"
               aria-describedby="textHelp"
             />
-            <div
-              id="textHelp"
-              className="form-text"
-              style={{ fontSize: "14px" }}
-            >
+            <div className="form-text" style={{ fontSize: "12px" }}>
               Type Keywords for better results
             </div>
           </div>
           <button
             type="submit"
-            className="btn btn-warning btn-sm"
+            className="btn btn-primary btn-sm d-inline-flex align-items-center gap-1"
             style={{ borderRadius: "10px" }}
             disabled={disable || query === ""}
             onClick={handleSearch}
           >
+            <Search size={13} />
             Search
-            <span
-              className={`${
-                loading ? "spinner-border spinner-border-sm mx-2" : ""
-              } ms-2`}
-            ></span>
+            {loading && (
+              <span className="spinner-border spinner-border-sm ms-1"></span>
+            )}
           </button>
           <button
             type="button"
-            className="btn btn-outline-warning btn-sm ms-2 text-secondary"
+            className="btn btn-outline-primary btn-sm ms-2 d-inline-flex align-items-center gap-1"
             style={{ borderRadius: "10px" }}
             onClick={handleClearAllHistory}
           >
-            Clear History{" "}
-            <span
-              className={`${
-                histLoader ? "spinner-border spinner-border-sm mx-2" : ""
-              }`}
-            ></span>
+            <Trash2 size={13} />
+            Clear
+            {histLoader && (
+              <span className="spinner-border spinner-border-sm ms-1"></span>
+            )}
           </button>
         </div>
-      ) : (
-        <Bookmarks host={host} />
       )}
+
+      {activeTab === "bookmark" && <Bookmarks host={host} />}
+      {activeTab === "combined" && <Combined host={host} />}
+
+      {/* ── Streaming step indicator ── */}
       <p className="m-2" style={{ fontSize: "12px" }}>
         {noti}
       </p>
@@ -243,71 +391,99 @@ const Popup = (props) => {
           </details>
         </div>
       )}
-      <div className="mt-2">
-        <div className="mb-2">
+
+      {/* ── Final answer card ── */}
+      {finalReceived && (parsed.summary || parsed.url) && (
+        <div
+          className="border rounded p-3 mt-2"
+          style={{ backgroundColor: "#f8f9ff", borderColor: "#d0d8ff" }}
+        >
           <p
-            classname="px-4"
-            style={{ fontSize: "13px", margin: "0", padding: "0" }}
+            className="text-muted mb-1"
+            style={{
+              fontSize: "11px",
+              fontWeight: 600,
+              letterSpacing: "0.5px",
+            }}
           >
-            {parsed.summary} <br />
-            {parsed.url && (
-              <>
-                <span className="fw-bold me-2">Url:</span>
-                {parsed.url}
-              </>
-            )}
+            ANSWER
           </p>
-        </div>
-        {docs.length > 0 && (
-          <p
-            className="fst-italic text-muted"
-            style={{ fontSize: "13px", margin: "0", padding: "0" }}
-          >
-            Below are the matched Sources
+          <p style={{ fontSize: "13px", margin: "0 0 6px 0" }}>
+            {parsed.summary}
           </p>
-        )}
-        {docs.length > 0 &&
-          docs.map((doc) => (
-            <div
-              className="bg-light p-2 border rounded mt-1"
-              onClick={() => {
-                chrome.tabs.create({ url: doc.metadata.source });
+          {parsed.url && (
+            <a
+              href={parsed.url}
+              onClick={(e) => {
+                e.preventDefault();
+                chrome.tabs.create({ url: parsed.url });
               }}
-              data-toggle="tooltip"
-              data-placement="top"
-              title={doc.metadata.source}
+              style={{ fontSize: "12px", wordBreak: "break-all" }}
             >
-              <div style={{ cursor: "pointer" }}>
-                <p style={{ margin: "0", padding: "0", fontSize: "13px" }}>
-                  {doc.metadata.source &&
-                    extractDomainName(doc.metadata.source)
-                      .charAt(0)
-                      .toUpperCase() +
-                      extractDomainName(doc.metadata.source).slice(1)}{" "}
-                  {doc.metadata.title.length > 0
-                    ? `| ${doc.metadata.title}`
-                    : ""}
+              {parsed.url}
+            </a>
+          )}
+        </div>
+      )}
+
+      {/* ── Matched sources ── */}
+      <div className="mt-2">
+        {/* Combined view: split by source type */}
+        {isCombined && docs.length > 0 && (
+          <div>
+            {historyDocs.length > 0 && (
+              <div className="mt-2">
+                <p
+                  className="text-muted mb-1"
+                  style={{
+                    fontSize: "11px",
+                    fontWeight: 600,
+                    letterSpacing: "0.5px",
+                  }}
+                >
+                  FROM HISTORY
                 </p>
-                <div className="d-flex">
-                  <p
-                    className="text-muted flex-grow-1"
-                    style={{ fontSize: "12px", margin: "0", padding: "0" }}
-                  >
-                    {getShortUrl(doc.metadata.source)}
-                  </p>
-                  {historyTab && (
-                    <p
-                      className="text-muted"
-                      style={{ fontSize: "12px", margin: "0", padding: "0" }}
-                    >
-                      {getDaysAgo(doc.metadata.date)}
-                    </p>
-                  )}
-                </div>
+                {historyDocs.map((doc, i) => (
+                  <DocCard key={i} doc={doc} showDate={true} />
+                ))}
               </div>
-            </div>
-          ))}
+            )}
+            {bookmarkDocs.length > 0 && (
+              <div className="mt-2">
+                <p
+                  className="text-muted mb-1"
+                  style={{
+                    fontSize: "11px",
+                    fontWeight: 600,
+                    letterSpacing: "0.5px",
+                  }}
+                >
+                  FROM BOOKMARKS
+                </p>
+                {bookmarkDocs.map((doc, i) => (
+                  <DocCard key={i} doc={doc} showDate={false} />
+                ))}
+              </div>
+            )}
+          </div>
+        )}
+
+        {/* History / Bookmark view: flat list */}
+        {!isCombined && docs.length > 0 && (
+          <div>
+            <p
+              className="fst-italic text-muted mb-1"
+              style={{ fontSize: "13px" }}
+            >
+              Matched Sources
+            </p>
+            {docs.map((doc, i) => (
+              <DocCard key={i} doc={doc} showDate={activeTab === "history"} />
+            ))}
+          </div>
+        )}
       </div>
+
       {!updateFlag && <Update handleShowUpdate={handleShowUpdate} />}
     </div>
   );

--- a/src/Components/Update.js
+++ b/src/Components/Update.js
@@ -1,31 +1,32 @@
+import { ArrowRight } from "lucide-react";
+
 const Update = ({ handleShowUpdate }) => {
   return (
     <div>
-      <div class="alert alert-success alert-dismissible fade show" role="alert">
+      <div
+        className="alert alert-success alert-dismissible fade show mt-3"
+        role="alert"
+      >
         <div className="d-flex flex-column justify-content-start mb-2">
-          <h5 class="alert-heading" style={{ padding: "0px", margin: "0px" }}>
-            Whats New!
+          <h5
+            className="alert-heading"
+            style={{ padding: "0px", margin: "0px" }}
+          >
+            What's New!
           </h5>
-          <span style={{ fontSize: "12px" }}>v1.7</span>
+          <span style={{ fontSize: "12px" }}>v1.75</span>
         </div>
-        {/* <p style={{ fontSize: "14px", margin: "0" }}>
-          Faster streaming pipeline
-        </p> */}
-        <p style={{ fontSize: "14px", margin: "0" }}>
-          Improved result consistency
+        <p className="d-flex align-items-start gap-1" style={{ fontSize: "13px", margin: "0 0 4px" }}>
+          <ArrowRight size={14} className="mt-1 flex-shrink-0 text-success" />
+          <span><strong>Combined Mode — </strong>Search history <strong>and</strong> bookmarks at once</span>
         </p>
-        <p style={{ fontSize: "14px", margin: "0" }}>
-          Better retrieval quality
-        </p>
-        <p style={{ fontSize: "14px", margin: "1px 0 0" }}>AI Model refresh</p>
-        {/* <p style={{ fontSize: "14px", margin: "0" }}>Enhanced Storage</p> */}
-        <p className="text-danger" style={{ fontSize: "14px", margin: "0" }}>
-          Bug Fixes
+        <p className="d-flex align-items-start gap-1" style={{ fontSize: "13px", margin: "0" }}>
+          <ArrowRight size={14} className="mt-1 flex-shrink-0 text-success" />
+          <span>Faster search with smarter result filtering</span>
         </p>
         <button
           type="button"
-          class="btn-close"
-          data-bs-dismiss="alert"
+          className="btn-close"
           aria-label="Close"
           onClick={handleShowUpdate}
         ></button>

--- a/src/context/UserState.js
+++ b/src/context/UserState.js
@@ -3,7 +3,7 @@ import { userContext } from "./userContext";
 import { initializeUserId } from "../components/UserId";
 
 const initialState = {
-  historyTab: true,
+  activeTab: "history", // "history" | "bookmark" | "combined"
   query: "",
   head: "",
   parsed: { summary: "", url: null },
@@ -37,6 +37,50 @@ const UserState = ({ children }) => {
     dispatch({ type: "SET_STATE", payload });
   }, []);
 
+  const syncCombined = useCallback(
+    async (host, historyData, bookmarkData, userId) => {
+      const cappedHistory = historyData.slice(-50);
+      const sortedBookmarks = [...bookmarkData].sort((a, b) => b.date - a.date);
+      const halfCount = Math.ceil(sortedBookmarks.length / 2);
+      const cappedBookmarks = sortedBookmarks.slice(0, halfCount);
+      try {
+        await fetch(`${host}/save-data`, {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({
+            data: cappedHistory,
+            userId: `${userId}:c`,
+            flag: "combined",
+            bookmarks: cappedBookmarks,
+          }),
+        });
+      } catch (error) {
+        setState({ noti: "There is a problem syncing combined data" });
+      }
+    },
+    [setState],
+  );
+
+  const syncBookmarks = useCallback(
+    async (host, bookmarkData, userId) => {
+      if (!bookmarkData || bookmarkData.length === 0) return;
+      try {
+        await fetch(`${host}/save-data`, {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({
+            data: bookmarkData,
+            userId: `${userId}:b`,
+            flag: "bookmark",
+          }),
+        });
+      } catch (error) {
+        setState({ noti: "There is a problem syncing bookmarks" });
+      }
+    },
+    [setState],
+  );
+
   const syncHistory = useCallback(
     async (host, historyData, userId) => {
       if (!historyData || historyData.length === 0) {
@@ -68,11 +112,11 @@ const UserState = ({ children }) => {
     async (host) => {
       const result = await chrome.storage.local.get({ navigationData: [] });
       const uid = await initializeUserId();
-      const upflag = await chrome.storage.local.get("sm-update-flag-v1.7");
+      const upflag = await chrome.storage.local.get("sm-update-flag-v1.75");
       setState({
         data: result,
         userId: uid,
-        updateFlag: Boolean(upflag["sm-update-flag-v1.7"]),
+        updateFlag: Boolean(upflag["sm-update-flag-v1.75"]),
       });
     },
     [setState],
@@ -97,7 +141,7 @@ const UserState = ({ children }) => {
           method: "POST",
           headers: { "Content-Type": "application/json" },
           body: JSON.stringify({
-            userId: `${userId}:${flag === "history" ? "h" : "b"}`,
+            userId: `${userId}:${flag === "history" ? "h" : flag === "bookmark" ? "b" : "c"}`,
             query,
             flag,
           }),
@@ -227,7 +271,7 @@ const UserState = ({ children }) => {
 
   return (
     <userContext.Provider
-      value={{ state, setState, initializePopup, syncHistory, searchStream }}
+      value={{ state, setState, initializePopup, syncHistory, syncBookmarks, syncCombined, searchStream }}
     >
       {children}
     </userContext.Provider>


### PR DESCRIPTION
### Summary

- **Combined Mode** — New third search tab that searches browser history and bookmarks simultaneously. History is capped at 50 most-recent items; bookmarks use the newest half of the user's total collection to keep token usage low.
- **UI Overhaul** — Navigation replaced with a dropdown (History / Bookmarks / Combined) with color-coded icons and a "NEW" badge that dismisses alongside the update banner. SurfMind header uses a blue-to-purple gradient. Combined results are split into "FROM HISTORY" and "FROM BOOKMARKS" sections.
- **Icons** — Added lucide-react icons throughout: Search, Trash2, History, Bookmark, GitMerge, ArrowRight.
- **Pre-sync on mount** — Bookmarks and combined data are uploaded to the backend as soon as the relevant tab is opened, removing upload latency from the search critical path.
- **Fairer RAG for combined search** — BM25 + FAISS retrieval now runs separately per source (parallel via ThreadPoolExecutor), preventing history from dominating all k=3 slots. LLM-as-judge post-processing also runs per source sequentially to avoid rate limits and bias against sparse bookmark titles.
- **Updated relevance prompt** — Removed "strict" wording; judges bookmarks on title/URL match, not content richness.
- **Bug fixes** — Update banner now disappears immediately on dismiss (fixed `updateFlag` logic). Dropdown menu positioning fixed for Chrome extension popup context (bypassed Bootstrap Popper.js with explicit inline CSS).

### Backend changes

- New `combined` flag in `/save-data` stores history (`user:{id}:ch`) and bookmarks (`user:{id}:cb`) under separate Redis sub-keys.
- `/search-stream` loads both sub-keys when `flag == "combined"` and calls `stream_combined_rag()`.
- New `Ans_combined` parser model with `url`, `date`, and `source_type` fields.
- New `combined` prompt section in `prompts.yml`.
- Parallel BM25 + FAISS retrieval via `ThreadPoolExecutor`.

### Test plan

- [ ] Combined search returns results from both history and bookmarks
- [ ] History capped at 50, bookmarks capped at half (newest first)
- [ ] Dismissing the update banner immediately hides both the banner and the "NEW" badge
- [ ] Dropdown menu renders correctly within the extension popup
- [ ] Gradient appears correctly on the SurfMind header text
- [ ] All three tabs (History / Bookmarks / Combined) search and stream results correctly
